### PR TITLE
Move permissions into the timodule.xml

### DIFF
--- a/timodule.xml
+++ b/timodule.xml
@@ -26,6 +26,10 @@
 	<iphone>
 	</iphone>
 	<android xmlns:android="http://schemas.android.com/apk/res/android">
+	<manifest>
+          <uses-permission android:name="android.permission.BLUETOOTH"/>
+          <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
+        </manifest
 	</android>
 	<mobileweb>
 	</mobileweb>


### PR DESCRIPTION
These are two fewer lines that the user needs to add to their tiapp.xml

When the appid can be passed through to the generated androidManifest.xml we can move the rest of the edits here as well.
